### PR TITLE
Update signup_policy.js

### DIFF
--- a/addons/auth_password_policy_signup/static/src/js/signup_policy.js
+++ b/addons/auth_password_policy_signup/static/src/js/signup_policy.js
@@ -7,12 +7,14 @@ import PasswordMeter from "@auth_password_policy_signup/js/password_meter";
 const signupForm = document.querySelector('.oe_signup_form, .oe_reset_password_form');
 if (signupForm) {
     const password = document.querySelector("[type=password][minlength]");
-    const minlength = Number(password.getAttribute("minlength"));
-    if (!isNaN(minlength)) {
-        const meter = new PasswordMeter(null, new ConcretePolicy({minlength}), recommendations);
-        meter.insertAfter(password);
-        password.addEventListener("input", (e) => {
-            meter.update(e.target.value);
-        });
+    if(password and !isNan(password)){
+        const minlength = Number(password.getAttribute("minlength"));
+        if (!isNaN(minlength)) {
+            const meter = new PasswordMeter(null, new ConcretePolicy({minlength}), recommendations);
+            meter.insertAfter(password);
+            password.addEventListener("input", (e) => {
+                meter.update(e.target.value);
+            });
+        }
     }
 }


### PR DESCRIPTION
"password is null" error was getting here because password input is not available and for that we need to check password and then process the rest of logic.

Description of the issue/feature this PR addresses: when click on reset password at that time "password is null" error was raised.we have solved this with condition added on js to check password input

Current behavior before PR: when click on reset password at that time "password is null" error was raised

Desired behavior after PR is merged: it should not throw error when click on reset password though there is no password field available.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
